### PR TITLE
For whatever reason, the submission endpoint needed a user id that it…

### DIFF
--- a/app/controllers/submission.js
+++ b/app/controllers/submission.js
@@ -49,11 +49,6 @@ function submitGenesAndAnnotations(req, res, next) {
 		return response.badRequest(res, `${req.body.publicationId} is not a DOI or Pubmed ID`);
 	}
 
-	// We bundle submitter ID in with the submission request, but it needs to match the authenticated user
-	if (req.user.attributes.id !== req.body.submitterId) {
-		return response.unauthorized(res, 'submitterId does not match authenticated user');
-	}
-
 	// Perform the whole addition in a transaction so we can rollback if something goes horribly wrong.
 	bookshelf.transaction(transaction => {
 

--- a/test/controllers/submission_test.js
+++ b/test/controllers/submission_test.js
@@ -35,7 +35,6 @@ describe('Submission Controller', function() {
 		// Tests will modify this as needed
 		this.currentTest.submission = {
 			publicationId: '10.1234/thing.anotherthing',
-			submitterId: testdata.users[0].id,
 			genes: [
 				{
 					locusName: 'AT1G10000',
@@ -153,21 +152,6 @@ describe('Submission Controller', function() {
 				.end((err, res) => {
 					chai.expect(res.status).to.equal(400);
 					chai.expect(res.text).to.equal(`${badPubId} is not a DOI or Pubmed ID`);
-					done();
-				});
-		});
-
-		it('Submitter id must match authenticated user', function(done) {
-			const nonMatchingUser = testdata.users[1];
-			this.test.submission.submitterId = nonMatchingUser.id;
-
-			chai.request(server)
-				.post('/api/submission/')
-				.send(this.test.submission)
-				.set({Authorization: `Bearer ${testToken}`})
-				.end((err, res) => {
-					chai.expect(res.status).to.equal(401);
-					chai.expect(res.text).to.equal('submitterId does not match authenticated user');
 					done();
 				});
 		});


### PR DESCRIPTION
… didn't use at all.