### PR TITLE
Truncate synonym names longer than 255 characters, with tests.

### DIFF
--- a/app/services/obo_importer/gene_ontology_importer.js
+++ b/app/services/obo_importer/gene_ontology_importer.js
@@ -169,6 +169,12 @@ class DataImporter extends stream.Writable {
 	 */
 	_addSynonym(synonymString, keywordId) {
 		let name = synonymString.split('"')[1];
+
+		// PostgreSQL has an issue with names longer than 255 characters
+		if (name.length > 255) {
+			name = name.substring(0, 252) + '...';
+		}
+
 		return Synonym.where({keyword_id: keywordId, name: name})
 			.fetch()
 			.then(synonym => {

--- a/test/lib/obo_importer_test.js
+++ b/test/lib/obo_importer_test.js
@@ -54,6 +54,19 @@ describe('OBO Data Importer', function() {
 			.then(synonyms => chai.expect(synonyms).to.have.lengthOf(1));
 	});
 
+	it('Long synonym names are truncated', function() {
+		// 252 characters plus an ellipsis
+		const truncatedName = 'This is a really long synonym that\'s too big for ' +
+			'the database, so the name will be truncated to something smaller than ' +
+			'this. That\'s it, really. The rest of this description is just redundant, ' +
+			'verbose nonsense to hit the character limit for truncation, ...';
+
+		return Synonym.where('name', 'LIKE', '%really long synonym%').fetch().then(synonym => {
+			chai.expect(synonym.get('name')).to.equal(truncatedName);
+			chai.expect(synonym.get('name')).to.have.lengthOf(255);
+		});
+	});
+
 	it('Keyword with no KeywordType uses default KeywordType', function() {
 		return Keyword.where({external_id: 'GO:0000002'})
 			.fetch({withRelated: 'keywordType'})

--- a/test/lib/test_terms.obo
+++ b/test/lib/test_terms.obo
@@ -9,6 +9,7 @@ def: "This is the general case for what a term will look like" [GOC:mah]
 synonym: "a synonym" RELATED []
 synonym: "another synonym" RELATED [GOC:mah]
 synonym: "yet another synonym" RELATED [GOC:mah]
+synonym: "This is a really long synonym that's too big for the database, so the name will be truncated to something smaller than this. That's it, really. The rest of this description is just redundant, verbose nonsense to hit the character limit for truncation, so yeah."
 is_a: GO:0004520 ! term not in this file
 is_a: GO:0048311 ! another term not in this file
 


### PR DESCRIPTION
closes #119 