### PR TITLE
Test for case-insensitive searches

### DIFF
--- a/test/controllers/keyword_test.js
+++ b/test/controllers/keyword_test.js
@@ -140,6 +140,20 @@ describe('Keyword Controller', function() {
 				});
 		});
 
+		it('Keyword search is case insensitive', function(done) {
+			const sillyCaseName = 'tESt TErm 001';
+			const expectedKeyword = testdata.keywords[0];
+			chai.request(server)
+				.get(`/api/keyword/search?substring=${sillyCaseName}`)
+				.end((err, res) => {
+				console.log(res.body);
+					chai.expect(res.status).to.equal(200);
+					chai.expect(res.body).to.have.lengthOf(1);
+					chai.expect(res.body[0]).to.contain(expectedKeyword);
+					done();
+				});
+		});
+
 		it('Search throws an error when substring is not provided', function(done) {
 			const testKeywordScope = testdata.keyword_types[0].name;
 


### PR DESCRIPTION
Turns out `WHERE name LIKE '%<input>%'` is already case-insensitive, so we just added a test to verify.

Closes #127 