### PR TITLE
use upper case locus names when getting loci from RNA Central

### DIFF
--- a/app/lib/rna_central_api.js
+++ b/app/lib/rna_central_api.js
@@ -15,10 +15,10 @@ const BASE_URL = 'http://rnacentral.org/api/v1/rna';
  */
 function getLocusByName(name) {
 	return new Promise((resolve, reject) => {
-		let requestUrl = `${BASE_URL}/${name}?flat=true`;
+		let requestUrl = `${BASE_URL}/${name.toUpperCase()}?flat=true`;
 		request.get(requestUrl, (error, response, bodyJson) => {
 			if (error) reject(new Error(error));
-			else if (response.statusCode === 404) reject(new Error(`No Locus found for name ${name}`));
+			else if (response.statusCode === 404) reject(new Error(`No Locus found for name ${name.toUpperCase()}`));
 			else {
 				let body = JSON.parse(bodyJson);
 				let taxonId =  body.xrefs.results[0].taxid;

--- a/test/lib/rna_central_api_test.js
+++ b/test/lib/rna_central_api_test.js
@@ -43,9 +43,7 @@ describe('RNA Central API', function () {
 
 		return RNACentral.getLocusByName(lowercasedLocusName).then(result => {
 			chai.expect(result).to.deep.equal(expectedResponse);
-		}).catch(err => {
-			throw err;
-		})
+		});
 	});
 
 });

--- a/test/lib/rna_central_api_test.js
+++ b/test/lib/rna_central_api_test.js
@@ -31,4 +31,21 @@ describe('RNA Central API', function () {
 		});
 	});
 
+	it('Good but lower cased Locus name responds successfully', function() {
+		const goodLocusName = 'URS0000000018';
+		const lowercasedLocusName = goodLocusName.toLowerCase();
+		const expectedResponse = {
+			source: 'RNA Central',
+			locus_name: goodLocusName,
+			taxon_id: 77133,
+			taxon_name: 'uncultured bacterium'
+		};
+
+		return RNACentral.getLocusByName(lowercasedLocusName).then(result => {
+			chai.expect(result).to.deep.equal(expectedResponse);
+		}).catch(err => {
+			throw err;
+		})
+	});
+
 });


### PR DESCRIPTION
therefore this ensures that we can reliably get loci from RNA Central

Closes #90 