### PR TITLE
Fix Uniprot locus validation

### DIFF
--- a/app/lib/uniprot_api.js
+++ b/app/lib/uniprot_api.js
@@ -7,69 +7,42 @@ const NCBI = require('./ncbi_api');
 // ex: For "Vulpes vulpes (red fox)", capture "Vulpes vulpes"
 const TAXON_EXTRACTING_REGEX = /^(\b[\w. ]+\b) *(?:\(.*)?$/;
 const QUERY_RESULT_LIMIT = 10;
-const BASE_URL = 'http://www.uniprot.org/uniprot/?format=json';
+const BASE_URL = 'http://www.ebi.ac.uk/proteins/api/proteins/';
 
 /**
- * Gets a uniprot gene by name.
+ * Gets a uniprot locus by name.
  * These can look like A2BC19, P12345, or A0A022YWF9 for Uniprot.
- * Promise resolves with the single matching gene,
- * or rejects with error for several or zero matching genes.
+ * Promise resolves with the single matching locus,
+ * or rejects with error with no matching locus.
  *
  * @param name
  * @returns {Promise}
  */
 function getLocusByName(name) {
-	let requestUrl = `${BASE_URL}&limit=2&query=accession:${name}`;
+	let requestUrl = `${BASE_URL}${name}.json`;
 	return new Promise((resolve, reject) => {
 		request.get(requestUrl, (error, response, bodyJson) => {
 			if (error) {
 				reject(new Error(error));
-			} else if (!bodyJson) {
+			} else if (response.statusCode != 200) {
 				reject(new Error(`No Locus found for name ${name}`));
 			} else {
 				let body = JSON.parse(bodyJson);
-				if (body.length > 1) {
-					reject(new Error('Given ID matches multiple loci'));
-				} else {
-					let taxonName = body[0].organism.match(TAXON_EXTRACTING_REGEX)[1];
+				let taxonName = body.organism.names[0].value;
 
-					NCBI.getTaxonByScientificName(taxonName).then(taxonInfo => {
-						resolve({
-							source: 'Uniprot',
-							locus_name: body[0].id,
-							taxon_name: taxonName,
-							taxon_id: taxonInfo.taxId
-						});
+				NCBI.getTaxonByScientificName(taxonName).then(taxonInfo => {
+					resolve({
+						source: 'Uniprot',
+						locus_name: body.accession,
+						taxon_name: taxonName,
+						taxon_id: taxonInfo.taxId
 					});
-				}
+				});
 			}
 		});
 	});
 }
-
-/**
- * Returns a list of uniprot genes for a given query, organizing by best match.
- *
- * @param name
- */
-function searchGeneByName(name) {
-	let requestUrl = `${BASE_URL}&limit=${QUERY_RESULT_LIMIT}&query=${name}`;
-	return new Promise((resolve, reject) => {
-		request.get(requestUrl, (error, response, bodyJson) => {
-			if (error) {
-				reject(new Error(error));
-			} else if (!bodyJson) {
-				reject(new Error('Given query matches no genes'));
-			} else {
-				let body = JSON.parse(bodyJson);
-				resolve(body);
-			}
-		});
-	});
-}
-
 
 module.exports = {
-	getLocusByName,
-	searchGeneByName
+	getLocusByName
 };

--- a/test/lib/uniprot_api_test.js
+++ b/test/lib/uniprot_api_test.js
@@ -22,12 +22,12 @@ describe('Uniprot API', function () {
 			});
 	});
 
-	it('Partial existing ID causes error due to multiple results', function() {
+	it('Partial existing ID causes error because it doesn\'t exist', function() {
 		const validPartialId = 'Q131';
 		return Uniprot.getLocusByName(validPartialId).then(result => {
-			throw new Error('Did not reject when getting multiple values');
+			throw new Error('Did not reject with partial result');
 		}).catch(err => {
-			chai.expect(err.message).to.equal('Given ID matches multiple loci');
+			chai.expect(err.message).to.equal(`No Locus found for name ${validPartialId}`);
 		});
 	});
 
@@ -39,24 +39,4 @@ describe('Uniprot API', function () {
 			chai.expect(err.message).to.equal(`No Locus found for name ${fakeName}`);
 		});
 	});
-
-	it('Gene queries return a limited list of data', function() {
-		const requestLimit = 10;
-		const genericName = 'butter';
-		return Uniprot.searchGeneByName(genericName).then(result => {
-			chai.expect(result).to.have.length(requestLimit);
-		}).catch(err => {
-			throw err;
-		});
-	});
-
-	it('Gene queries that return no results causes error', function() {
-		const nonMatchingName = 'randomthing';
-		return Uniprot.searchGeneByName(nonMatchingName).then(result => {
-			throw new Error('Did not reject when search returned no values');
-		}).catch(err => {
-			chai.expect(err.toString()).to.contain('Given query matches no genes');
-		});
-	});
-
 });


### PR DESCRIPTION
It looks like Uniprot's REST API dropped support for JSON over the summer for some reason, but the underlying UniProtKB protein database still supports it, so I switched it over. 

This database doesn't support multiple results, so I had to remove the `searchGeneByName` function. The function had 0 references other than tests, so it was just dead code anyways.