### PR TITLE
Add keyword_mapping eco_id foreign key

### DIFF
--- a/migrations/20171012202821_add_eco_id_foreign_key.js
+++ b/migrations/20171012202821_add_eco_id_foreign_key.js
@@ -1,0 +1,17 @@
+
+exports.up = function(knex, Promise) {
+	return knex.schema
+		.table('keyword_mapping', (table) => {
+			table.dropUnique('eco_id');
+			table.foreign('eco_id').references('keyword.external_id');
+		});
+};
+
+exports.down = function(knex, Promise) {
+	return knex.schema
+		.table('keyword_mapping', (table) => {
+			table.dropForeign('eco_id');
+			table.unique('eco_id');
+		});
+};
+


### PR DESCRIPTION
Changes:
- Updated keyword_mapping definition of eco_id to have a foreign key relationship to keyword.external_id.
- Removed excess unique constraint from eco_id since it is already a primary key.
- Updated keyword_mapping model to only attempt to add eco_id entries which have a matching external_id in keyword.