### PR TITLE
Add appspec yml and install script for codedeploy

### DIFF
--- a/appspec.yml
+++ b/appspec.yml
@@ -1,0 +1,11 @@
+version: 0.0
+os: linux
+files:
+  - source: /
+    destination: /home/ec2-user/codedeploy-back-landingpad/
+hooks:
+  AfterInstall:
+    - location: server-scripts/after-install
+      timeout: 300
+      runas: root
+

--- a/server-scripts/after-install
+++ b/server-scripts/after-install
@@ -1,0 +1,21 @@
+#!/bin/bash
+
+# Don't actually deploy yet (commented out)
+
+# source /home/ec2-user/db_env_vars
+# export NODE_ENV=production
+# export RESOURCEROOT=/home/ec2-user/resources
+
+cd /home/ec2-user/codedeploy-back-landingpad/
+# npm install
+# npm run migrate
+# npm run exec knex seed:run
+
+# Replace the old deployment files with the new ones
+# rm -rf /home/ec2-user/deployments/toastdos-back
+# cp -r /home/ec2-user/codedeploy-back-landingpad/ /home/ec2-user/deployments/toastdos-back
+
+# Restart the service
+# sudo /usr/bin/systemctl restart toastdos-back
+
+


### PR DESCRIPTION
Adding `appspec.yml` and install script to test a manual code deploy deployment to EC2 without actually deploying changes to toastdos-back.

Issue #248