### PR TITLE
Improve keyword searching

### DIFF
--- a/app/controllers/keyword.js
+++ b/app/controllers/keyword.js
@@ -5,8 +5,8 @@ const { AnnotationTypeData } = require('../lib/annotation_submission_helper');
 
 const response = require('../lib/responses');
 const knex = require('../lib/bookshelf').knex;
+const { insensitiveLikeOperator: ILIKE_OPERATOR } = require('../../config');
 
-const KEYWORD_SUBSTRING_MIN_LENGTH = 3;
 const KEYWORD_SEARCH_LIMIT = 20;
 
 /**
@@ -81,13 +81,13 @@ function partialKeywordMatch(req, res) {
             // Create the subquerys for searching cannonical names and synonym names.
             const keywordQuery = knex.select(keywordFields)
                 .from('keyword')
-                .where('keyword.name', 'LIKE', `%${req.query.substring}%`)
-                .orWhere('external_id', 'LIKE', `%${req.query.substring}%`);
+                .where('keyword.name', ILIKE_OPERATOR, `%${req.query.substring}%`)
+                .orWhere('external_id', ILIKE_OPERATOR, `%${req.query.substring}%`);
 
             const synonymQuery = knex.select(synonymFields)
                 .from('synonym')
                 .leftJoin('keyword', 'keyword.id', 'synonym.keyword_id')
-                .where('synonym.name', 'LIKE', `%${req.query.substring}%`);
+                .where('synonym.name', ILIKE_OPERATOR, `%${req.query.substring}%`);
 
             // Union the results of the two query
             const unionQuery = keywordQuery.union(synonymQuery).as('unionQuery');

--- a/app/controllers/keyword.js
+++ b/app/controllers/keyword.js
@@ -1,6 +1,7 @@
 'use strict';
 
 const KeywordType = require('../models/keyword_type');
+const { AnnotationTypeData } = require('../lib/annotation_submission_helper');
 
 const response = require('../lib/responses');
 const knex = require('../lib/bookshelf').knex;
@@ -20,13 +21,6 @@ const KEYWORD_SEARCH_LIMIT = 20;
  * 400 for invalid substring or keyword_scope
  */
 function partialKeywordMatch(req, res) {
-    if (!req.query.substring) {
-        return response.badRequest(res, `'substring' is a required field`);
-    }
-
-    if (req.query.substring.length < KEYWORD_SUBSTRING_MIN_LENGTH) {
-        return response.badRequest(res, 'Keyword search string too short');
-    }
 
     // Verify / retrieve the provided KeywordType
     let keywordTypePromise;
@@ -38,6 +32,16 @@ function partialKeywordMatch(req, res) {
         });
     } else {
         keywordTypePromise = Promise.resolve(null);
+    }
+
+    let allowedEvidenceCodes = null;
+
+    if (req.query.annotation_type) {
+        if (!AnnotationTypeData.hasOwnProperty(req.query.annotation_type)) {
+            return response.badRequest(res, `Invalid 'annotation_type'`);
+        }
+
+        allowedEvidenceCodes = AnnotationTypeData[req.query.annotation_type].allowedEvidenceCodes;
     }
 
     keywordTypePromise
@@ -98,15 +102,26 @@ function partialKeywordMatch(req, res) {
             if (needsEcoId) {
                 finalQuery.leftJoin('keyword_mapping', 'unionQuery.external_id', 'keyword_mapping.eco_id');
                 finalQuery.whereNotNull('keyword_mapping.evidence_code');
+                if (allowedEvidenceCodes != null) {
+                    finalQuery.where(function() {
+                        allowedEvidenceCodes.forEach(item => {
+                            this.orWhere('keyword_mapping.evidence_code', '=', item);
+                        });
+                    });
+                }
             }
 
             // Make sure the keyword is not obsolete and that it has an external id.
             finalQuery.whereNot('is_obsolete', 1);
             finalQuery.whereNotNull('external_id');
 
-            // Order the canonical results first and only show 20.
-            finalQuery.orderByRaw('?? IS NOT NULL, LENGTH(??) ASC', ['syn', 'name']);
-            finalQuery.offset(0).limit(KEYWORD_SEARCH_LIMIT);
+            // Order by match length first if there is a substring, else alphabetically.
+            if (req.query.substring) {
+                finalQuery.orderByRaw('?? IS NOT NULL, LENGTH(??) ASC, LENGTH(??) ASC', ['syn', 'syn', 'name']);
+                finalQuery.offset(0).limit(KEYWORD_SEARCH_LIMIT);
+            } else {
+                finalQuery.orderByRaw('?? IS NOT NULL, ?? ASC, ?? ASC', ['syn', 'syn', 'name']);
+            }
             return finalQuery;
         })
         .then(results => response.ok(res, results))

--- a/app/controllers/keyword.js
+++ b/app/controllers/keyword.js
@@ -97,7 +97,7 @@ function partialKeywordMatch(req, res) {
             // If it's an eco, we need to add the eco_id.
             if (needsEcoId) {
                 finalQuery.leftJoin('keyword_mapping', 'unionQuery.external_id', 'keyword_mapping.eco_id');
-                finalQuery.whereNotNull('keyword_mapping.eco_id');
+                finalQuery.whereNotNull('keyword_mapping.evidence_code');
             }
 
             // Make sure the keyword is not obsolete and that it has an external id.

--- a/app/controllers/keyword.js
+++ b/app/controllers/keyword.js
@@ -105,7 +105,7 @@ function partialKeywordMatch(req, res) {
             finalQuery.whereNotNull('external_id');
 
             // Order the canonical results first and only show 20.
-            finalQuery.orderBy('synonym', 'desc');
+            finalQuery.orderByRaw('?? IS NOT NULL, LENGTH(??) ASC', ['syn', 'name']);
             finalQuery.offset(0).limit(KEYWORD_SEARCH_LIMIT);
             return finalQuery;
         })

--- a/app/controllers/keyword.js
+++ b/app/controllers/keyword.js
@@ -96,7 +96,8 @@ function partialKeywordMatch(req, res) {
 
             // If it's an eco, we need to add the eco_id.
             if (needsEcoId) {
-                finalQuery.rightJoin('keyword_mapping', 'unionQuery.external_id', 'keyword_mapping.eco_id');
+                finalQuery.leftJoin('keyword_mapping', 'unionQuery.external_id', 'keyword_mapping.eco_id');
+                finalQuery.whereNotNull('keyword_mapping.eco_id');
             }
 
             // Make sure the keyword is not obsolete and that it has an external id.

--- a/app/lib/annotation_submission_helper.js
+++ b/app/lib/annotation_submission_helper.js
@@ -44,35 +44,41 @@ const AnnotationTypeData = {
         name: 'Molecular Function',
         format: AnnotationFormats.GENE_TERM,
         keywordScope: 'molecular_function',
-        aspect: 'F'
+        aspect: 'F',
+        allowedEvidenceCodes: ['IDA', 'IPI', 'IGI', 'IMP', 'EXP']
     },
     BIOLOGICAL_PROCESS: {
         name: 'Biological Process',
         format: AnnotationFormats.GENE_TERM,
         keywordScope: 'biological_process',
-        aspect: 'P'
+        aspect: 'P',
+        allowedEvidenceCodes: ['IDA', 'IPI', 'IGI', 'IMP', 'EXP', 'IEP']
     },
     SUBCELLULAR_LOCATION: {
         name: 'Subcellular Location',
         format: AnnotationFormats.GENE_TERM,
         keywordScope: 'cellular_component',
-        aspect: 'C'
+        aspect: 'C',
+        allowedEvidenceCodes: ['IDA', 'IEP', 'EXP']
     },
     ANATOMICAL_LOCATION: {
         name: 'Anatomical Location',
         format: AnnotationFormats.GENE_TERM,
         keywordScope: 'plant_anatomy',
-        aspect: 'S'
+        aspect: 'S',
+        allowedEvidenceCodes: ['IDA', 'IEP', 'EXP']
     },
     TEMPORAL_EXPRESSION: {
         name: 'Temporal Expression',
         format: AnnotationFormats.GENE_TERM,
         keywordScope: 'plant_structure_development_stage',
-        aspect: 'G'
+        aspect: 'G',
+        allowedEvidenceCodes: ['IDA', 'IEP', 'EXP']
     },
     PROTEIN_INTERACTION: {
         name: 'Protein Interaction',
-        format: AnnotationFormats.GENE_GENE
+        format: AnnotationFormats.GENE_GENE,
+        allowedEvidenceCodes: ['IPI']
     },
     COMMENT: {
         name: 'Comment',

--- a/config/development.js
+++ b/config/development.js
@@ -3,23 +3,24 @@ const tsFormat = () => (new Date()).toLocaleTimeString();
 
 module.exports = {
 	// development environment configuration
-	logger: {
-		level: 'debug',
-		levels: {
-			'debug': 0,
-			'info': 1,
-			'warn': 2,
-			'error': 3
-		},
-		name: 'developement-log',
-		filename: './logs/development.log',
-		json: false,
-		timestamp: tsFormat
-	},
-	database: require('../knexfile').development,
-	jwt: {
-		algorithm: 'RS256',
-		expiresIn: '1800000', // expire after 1 hour
-	},
-	resourceRoot: process.env.RESOURCEROOT
+    logger: {
+        level: 'debug',
+        levels: {
+            'debug': 0,
+            'info': 1,
+            'warn': 2,
+            'error': 3
+        },
+        name: 'developement-log',
+        filename: './logs/development.log',
+        json: false,
+        timestamp: tsFormat
+    },
+    database: require('../knexfile').development,
+    jwt: {
+        algorithm: 'RS256',
+        expiresIn: '1800000', // expire after 1 hour
+    },
+    resourceRoot: process.env.RESOURCEROOT,
+    insensitiveLikeOperator: 'LIKE'
 };

--- a/config/production.js
+++ b/config/production.js
@@ -3,23 +3,24 @@ const tsFormat = () => (new Date()).toLocaleTimeString();
 
 module.exports = {
 	// production environment configuration
-	logger: {
-		level: 'info',
-		levels: {
-			'debug': 0,
-			'info': 1,
-			'warn': 2,
-			'error': 3
-		},
-		name: 'production-log',
-		filename: './logs/production.log',
-		json: false,
-		timestamp: tsFormat
-	},
-	database: require('../knexfile').production,
-	jwt: {
-		algorithm: 'RS256',
-		expiresIn: '9000000', // expire after 5 hours
-	},
-	resourceRoot: process.env.RESOURCEROOT
+    logger: {
+        level: 'info',
+        levels: {
+            'debug': 0,
+            'info': 1,
+            'warn': 2,
+            'error': 3
+        },
+        name: 'production-log',
+        filename: './logs/production.log',
+        json: false,
+        timestamp: tsFormat
+    },
+    database: require('../knexfile').production,
+    jwt: {
+        algorithm: 'RS256',
+        expiresIn: '9000000', // expire after 5 hours
+    },
+    resourceRoot: process.env.RESOURCEROOT,
+    insensitiveLikeOperator: 'ILIKE'
 };

--- a/config/staging.js
+++ b/config/staging.js
@@ -3,23 +3,24 @@ const tsFormat = () => (new Date()).toLocaleTimeString();
 
 module.exports = {
 	// local staging environment configuration
-	logger: {
-		level: 'info',
-		levels: {
-			'debug': 0,
-			'info': 1,
-			'warn': 2,
-			'error': 3
-		},
-		name: 'staging-log',
-		filename: './logs/staging.log',
-		json: false,
-		timestamp: tsFormat
-	},
-	database: require('../knexfile').staging,
-	jwt: {
-		algorithm: 'RS256',
-		expiresIn: '1800000', // expire after 1 hour
-	},
-	resourceRoot: process.env.RESOURCEROOT
+    logger: {
+        level: 'info',
+        levels: {
+            'debug': 0,
+            'info': 1,
+            'warn': 2,
+            'error': 3
+        },
+        name: 'staging-log',
+        filename: './logs/staging.log',
+        json: false,
+        timestamp: tsFormat
+    },
+    database: require('../knexfile').staging,
+    jwt: {
+        algorithm: 'RS256',
+        expiresIn: '1800000', // expire after 1 hour
+    },
+    resourceRoot: process.env.RESOURCEROOT,
+    insensitiveLikeOperator: 'ILIKE'
 };

--- a/config/test.js
+++ b/config/test.js
@@ -3,18 +3,19 @@ const tsFormat = () => (new Date()).toLocaleTimeString();
 
 module.exports = {
     //test environment configuration
-	logger: {
-		colorize: true,
-		level: 'warn',
-		levels: {
-			'debug': 0,
-			'info': 1,
-			'warn': 2,
-			'error': 3
-		},
-		timestamp: tsFormat
-	},
-	database: require('../knexfile').test,
-	testsecret: 'testsecret',
-	resourceRoot: process.env.RESOURCEROOT
+    logger: {
+        colorize: true,
+        level: 'warn',
+        levels: {
+            'debug': 0,
+            'info': 1,
+            'warn': 2,
+            'error': 3
+        },
+        timestamp: tsFormat
+    },
+    database: require('../knexfile').test,
+    testsecret: 'testsecret',
+    resourceRoot: process.env.RESOURCEROOT,
+    insensitiveLikeOperator: 'LIKE'
 };

--- a/test/controllers/keyword_test.js
+++ b/test/controllers/keyword_test.js
@@ -205,24 +205,6 @@ describe('Keyword Controller', function() {
                 });
         });
 
-        /*it('Well-formed search responds with correct data', function(done) {
-            const testKeywordScope = testdata.keyword_types[0].name;
-            const testSubstr = 'Test Term 00';
-            const expectedKeywords = [
-                testdata.keywords[0],
-                testdata.keywords[1]
-            ];
-
-            chai.request(server)
-                .get(`/api/keyword/search?substring=${testSubstr}&keyword_scope=${testKeywordScope}`)
-                .end((err, res) => {
-                    chai.expect(res.status).to.equal(200);
-                    chai.expect(res.body).to.have.length(expectedKeywords.length);
-                    chai.expect(res.body).to.containSubset(expectedKeywords);
-                    done();
-                });
-        });*/
-
     });
 
 });

--- a/test/controllers/keyword_test.js
+++ b/test/controllers/keyword_test.js
@@ -23,15 +23,14 @@ describe('Keyword Controller', function() {
 
     describe('GET /api/keyword/search', function() {
 
-        it('Search is not performed with too few characters', function(done) {
+        it('Search is performed with any characters', function(done) {
             const testKeywordScope = testdata.keyword_types[0].name;
             const shortSubstr = 'ab';
 
             chai.request(server)
                 .get(`/api/keyword/search?substring=${shortSubstr}&keyword_scope=${testKeywordScope}`)
                 .end((err, res) => {
-                    chai.expect(res.status).to.equal(400);
-                    chai.expect(res.text).to.equal('Keyword search string too short');
+                    chai.expect(res.status).to.equal(200);
                     done();
                 });
         });
@@ -175,18 +174,6 @@ describe('Keyword Controller', function() {
                     chai.expect(res.status).to.equal(200);
                     chai.expect(res.body).to.have.lengthOf(1);
                     chai.expect(res.body[0]).to.contain(expectedKeyword);
-                    done();
-                });
-        });
-
-        it('Search throws an error when substring is not provided', function(done) {
-            const testKeywordScope = testdata.keyword_types[0].name;
-
-            chai.request(server)
-                .get(`/api/keyword/search?keyword_scope=${testKeywordScope}`)
-                .end((err, res) => {
-                    chai.expect(res.status).to.equal(400);
-                    chai.expect(res.text).to.equal(`'substring' is a required field`);
                     done();
                 });
         });

--- a/test/controllers/keyword_test.js
+++ b/test/controllers/keyword_test.js
@@ -205,6 +205,24 @@ describe('Keyword Controller', function() {
                 });
         });
 
+        /*it('Well-formed search responds with correct data', function(done) {
+            const testKeywordScope = testdata.keyword_types[0].name;
+            const testSubstr = 'Test Term 00';
+            const expectedKeywords = [
+                testdata.keywords[0],
+                testdata.keywords[1]
+            ];
+
+            chai.request(server)
+                .get(`/api/keyword/search?substring=${testSubstr}&keyword_scope=${testKeywordScope}`)
+                .end((err, res) => {
+                    chai.expect(res.status).to.equal(200);
+                    chai.expect(res.body).to.have.length(expectedKeywords.length);
+                    chai.expect(res.body).to.containSubset(expectedKeywords);
+                    done();
+                });
+        });*/
+
     });
 
 });


### PR DESCRIPTION
This PR changes the backend to:

- support case insensitive searching on postgres
- restrict eco searches to only certain evidence codes
- change sorting to be based on length of match
- show alphabetical list if no search string
- allow 0-length searches to prepopulate all keyword terms for an annotation type