### PR TITLE
Stop curator being saved as submitter after curating

### DIFF
--- a/app/services/obo_importer/cli.js
+++ b/app/services/obo_importer/cli.js
@@ -3,7 +3,7 @@
 /**
  * This is a small command line utility to manually trigger an obo update.
  * Target options include:
- *     eco, po, go - download / run update with pre-defined obo resource
+ *     eco, po, go, ecomap - download / run update with pre-defined obo resource
  *     filepath    - run import on specified file, if exists
  *     url         - download / run update with obo at URL
  */


### PR DESCRIPTION
Adding a change that will stop submitting a curation from changing the annotation's original submitter to the curator.  Also adding a comment to cli.js that will reflect all the commands in that file.