### PR TITLE
Add User-Agent header to TAIR API requests for WAF (TAIR3-534)

### DIFF
--- a/app/lib/tair_api.js
+++ b/app/lib/tair_api.js
@@ -29,8 +29,15 @@ const DEFAULT_TAXON = {
  */
 function getLocusByName(name) {
     let requestUrl = `https://www.arabidopsis.org/api/loci/${name}`;
+    let requestOptions = {
+        url: requestUrl,
+        headers: {
+            'User-Agent': 'Mozilla/5.0 (compatible; GOAT/1.0; +https://goat.phoenixbioinfo.org)',
+            'Accept': 'application/json'
+        }
+    };
     return new Promise((resolve, reject) => {
-        request.get(requestUrl, (error, response, bodyJson) => {
+        request.get(requestOptions, (error, response, bodyJson) => {
             if (error) reject(new Error(error));
             else if (response.statusCode === 404) reject(new Error(`No Locus found for name ${name}`));
             else {


### PR DESCRIPTION
## Summary
- The arabidopsis.org WAF blocks requests with no/empty User-Agent header (returns 403)
- Added `User-Agent` and `Accept` headers to `getLocusByName()` in `tair_api.js`
- Verified against UAT: valid locus returns 200, invalid returns 404

## Test plan
- [x] Deploy tair3 loci endpoint to prod
- [ ] Deploy this change to GOAT
- [x] Verify AGI locus IDs (e.g. `AT1G10000`) are accepted in the submission form

Fixes TAIR3-534

🤖 Generated with [Claude Code](https://claude.com/claude-code)